### PR TITLE
Fix this value on LightResource events

### DIFF
--- a/plugins/default/light/components/LightUpdater.ts
+++ b/plugins/default/light/components/LightUpdater.ts
@@ -122,12 +122,12 @@ export default class LightUpdater {
     });
   }
 
-  private onLightResourceReceived(resourceId: string, resource: LightSettingsResource) {
+  private onLightResourceReceived = (resourceId: string, resource: LightSettingsResource) => {
     this.lightSettings = resource;
     this.updateLightShadowMap();
   }
 
-  private onLightResourceEdited(resourceId: string, command: string, propertyName: string) {
+  private onLightResourceEdited = (resourceId: string, command: string, propertyName: string) => {
     if (command === "setProperty" && propertyName === "shadowMapType") this.updateLightShadowMap();
   }
 }


### PR DESCRIPTION
The 'this' value was not correct and caused errors while loading prefabs with lights and/or while changing the light type.
