### PR TITLE
Fix model rendering inside prefabs

### DIFF
--- a/plugins/default/model/components/ModelRenderer.ts
+++ b/plugins/default/model/components/ModelRenderer.ts
@@ -318,6 +318,8 @@ export default class ModelRenderer extends SupEngine.ActorComponent {
   clearPose() {
     if (this.threeMesh == null) return;
 
+    if ((<THREE.SkinnedMesh>this.threeMesh).skeleton == null) return;
+
     for (let i = 0; i < (<THREE.SkinnedMesh>this.threeMesh).skeleton.bones.length; i++) {
       let bone = (<THREE.SkinnedMesh>this.threeMesh).skeleton.bones[i];
       bone.matrix.fromArray(this.asset.bones[i].matrix);
@@ -357,6 +359,8 @@ export default class ModelRenderer extends SupEngine.ActorComponent {
         this.isAnimationPlaying = false;
       }
     }
+
+    if ((<THREE.SkinnedMesh>this.threeMesh).skeleton == null) return;
 
     for (let i = 0; i < (<THREE.SkinnedMesh>this.threeMesh).skeleton.bones.length; i++) {
       let bone = (<THREE.SkinnedMesh>this.threeMesh).skeleton.bones[i];


### PR DESCRIPTION
ClearPose() was called while loading the model renderer component, but it failed because there was no skeleton ( static .obj model). This seemed to happen with prefabs. Added a check to make sure there is a skeleton before attempting to access it.
